### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/systemtap.spec
+++ b/rpm/systemtap.spec
@@ -44,6 +44,7 @@ BuildRequires: pkgconfig(nss)
 BuildRequires: pkgconfig(sqlite3)
 # Needed for libstd++ < 4.0, without <tr1/memory>
 BuildRequires: pkgconfig(rpm) glibc-headers
+BuildRequires: pkgconfig(systemd)
 BuildRequires: elfutils-devel >= 0.142
 BuildRequires: readline-devel
 BuildRequires: ncurses-devel


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.